### PR TITLE
Directory fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,12 +101,16 @@ module.exports = function makeFetch (opts = {}) {
 
       if (method === 'PUT') {
         checkWritable(archive)
-        const { body } = opts
-        const source = bodyToStream(body, session)
-        const destination = archive.createWriteStream(path)
+        if (path.endsWith('/')) {
+          await archive.mkdir(path)
+        } else {
+          // Create a new file from the request body
+          const { body } = opts
+          const source = bodyToStream(body, session)
+          const destination = archive.createWriteStream(path)
 
-        await pump(source, destination)
-
+          await pump(source, destination)
+        }
         return new FakeResponse(200, 'OK', responseHeaders, intoStream(''), url)
       } else if (method === 'DELETE') {
         checkWritable(archive)

--- a/index.js
+++ b/index.js
@@ -169,11 +169,8 @@ module.exports = function makeFetch (opts = {}) {
         let statusCode = 200
 
         if (resolved.type === 'directory') {
-          const files = await Promise.all(await archive.readdir(finalPath).then(files => files.map(async fileName => {
-            const stats = await archive.stat(finalPath + '/' + fileName)
-            const stat = Array.isArray(stats) ? stats[0] : stats
-            return stat.isDirectory() ? fileName + '/' : fileName
-          })))
+          const stats = await archive.readdir(finalPath, { includeStats: true })
+          const files = stats.map(({ stat, name }) => (stat.isDirectory() ? `${name}/` : name))
 
           if (headers.get('Accept') === 'application/json') {
             const json = JSON.stringify(files, null, '\t')

--- a/index.js
+++ b/index.js
@@ -169,7 +169,12 @@ module.exports = function makeFetch (opts = {}) {
         let statusCode = 200
 
         if (resolved.type === 'directory') {
-          const files = await archive.readdir(finalPath)
+          const files = await Promise.all(await archive.readdir(finalPath).then(files => files.map(async fileName => {
+            const stats = await archive.stat(finalPath + '/' + fileName)
+            const stat = Array.isArray(stats) ? stats[0] : stats
+            return stat.isDirectory() ? fileName + '/' : fileName
+          })))
+
           if (headers.get('Accept') === 'application/json') {
             const json = JSON.stringify(files, null, '\t')
             stream = intoStream(Buffer.from(json))


### PR DESCRIPTION
Add functionality to fix https://github.com/RangerMauve/agregore-browser/issues/14 by appending '/' to the end of directory names in directory listings.

Additionally adds the ability to create empty directories via PUT request if a path name ends in a trailing '/'. It seems that this is generally non-standard behaviour for HTTP servers, so I'd love input if there's a more idiomatic way to do this.