### PR TITLE
Fix X-Resolve none

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ module.exports = function makeFetch (opts = {}) {
         }
         try {
           if (headers.get('X-Resolve') === 'none') {
-            stat = await archive.stat(path)
+            stat = await new Promise(resolve => archive.stat(path, (err, stat) => resolve(stat)))
           } else {
             const resolved = await resolveDatPathAwait(archive, path)
             finalPath = resolved.path


### PR DESCRIPTION
As of current, running an X-Resolve: none request fails with cause stat.IsDirectory is not a function due to stat not being set properly.

This seems to be due to `archive.stat` working in a weird way.

Wrapping it in a promise and mapping said promise to the internal function paramter of `archive.stat` seems to fix this.