### PR TITLE
Rewrite using make-fetch module, rename to `hyper-fetch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# dat-fetch
+# hyper-fetch
 
-Implementation of Fetch that uses the Dat SDK for loading p2p content
+Implementation of Fetch that uses the Hyper SDK for loading p2p content
 
-`npm install --save dat-fetch`
+`npm install --save hyper-fetch`
 
 ```javascript
-const fetch = require('dat-fetch')()
+const fetch = require('hyper-fetch')()
 
 const someURL = `hyper://blog.mauve.moe`
 
@@ -19,20 +19,20 @@ console.log(json)
 You can also use the bundled CLI
 
 ```
-npm i -g dat-fetch
+npm i -g hyper-fetch
 
-dat-fetch dat://somethingorother
+hyper-fetch hyper://somethingorother
 
 # Or
 
-npx dat-fetch dat://somethingorother
+npx hyper-fetch hyper://somethingorother
 ```
 
 ## API
 
 ### `makeFetch({Hyperdrive, resolveName, base, session, writable}) => fetch()`
 
-Creates a dat-fetch instance.
+Creates a hyper-fetch instance.
 
 The `base` parameter can be used to specify what the base URL is for relative paths like `fetch('./dat.json')`.
 

--- a/index.js
+++ b/index.js
@@ -1,25 +1,23 @@
 const resolveDatPath = require('resolve-dat-path')
 const Headers = require('fetch-headers')
 const mime = require('mime/lite')
-const concat = require('concat-stream')
 const SDK = require('dat-sdk')
-const { Readable } = require('stream')
 const parseRange = require('range-parser')
-const bodyToStream = require('fetch-request-body-to-stream')
-const pump = require('pump-promise')
 const makeDir = require('make-dir')
+const { Readable, pipelinePromise } = require('streamx')
+const makeFetch = require('make-fetch')
 
 const DAT_REGEX = /\w+:\/\/([^/]+)\/?([^#?]*)?/
 const NUMBER_REGEX = /^\d+$/
 const PROTOCOL_REGEX = /^\w+:\/\//
 const NOT_WRITABLE_ERROR = 'Archive not writable'
 
-const READABLE_ALLOW = ['GET', 'HEAD', 'DOWNLOAD', 'CLEAR']
-const WRITABLE_ALLOW = ['PUT', 'DELETE']
+const READABLE_ALLOW = ['GET', 'HEAD', 'TAGS', 'DOWNLOAD', 'CLEAR']
+const WRITABLE_ALLOW = ['PUT', 'DELETE', 'TAG', 'TAG-DELETE']
 const ALL_ALLOW = READABLE_ALLOW.concat(WRITABLE_ALLOW)
 
-module.exports = function makeFetch (opts = {}) {
-  let { Hyperdrive, resolveName, base, session, writable = false } = opts
+module.exports = function makeHyperFetch (opts = {}) {
+  let { Hyperdrive, resolveName, base, writable = false } = opts
 
   let sdk = null
   let gettingSDK = null
@@ -27,9 +25,288 @@ module.exports = function makeFetch (opts = {}) {
 
   const isSourceDat = base && (base.startsWith('dat://') || base.startsWith('hyper://'))
 
-  datFetch.close = () => onClose()
+  const fetch = makeFetch(hyperFetch)
 
-  return datFetch
+  fetch.close = () => onClose()
+
+  return fetch
+
+  async function hyperFetch ({ url, headers: rawHeaders, method, signal, body }) {
+    const isDatURL = url.startsWith('dat://') || url.startsWith('hyper://')
+    const urlHasProtocol = url.match(PROTOCOL_REGEX)
+
+    const shouldIntercept = isDatURL || (!urlHasProtocol && isSourceDat)
+
+    if (!shouldIntercept) throw new Error('Invalid protocol, must be dat:// or hyper://')
+
+    const headers = new Headers(rawHeaders || {})
+
+    const responseHeaders = {}
+    responseHeaders['Access-Control-Allow-Origin'] = '*'
+    responseHeaders['Allow-CSP-From'] = '*'
+    responseHeaders['Access-Control-Allow-Headers'] = '*'
+    responseHeaders['Cache-Control'] = 'no-cache'
+
+    try {
+      let { path, key, version } = parseDatURL(url)
+      if (!path) path = '/'
+
+      const resolve = await getResolve()
+
+      try {
+      console.log('Resolving')
+        key = await resolve(`dat://${key}`)
+      console.log('Resolved')
+      } catch (e) {
+        // Probably a domain that couldn't resolve
+        if (key.includes('.')) throw e
+      }
+
+      console.log('Getting drive')
+      const Hyperdrive = await getHyperdrive()
+      console.log('Got')
+
+      let archive = Hyperdrive(key)
+
+      console.log('Awaiting ready')
+      await archive.ready()
+      console.log('Ready')
+
+      if (version) {
+        console.log('Checking out version')
+        if (NUMBER_REGEX.test(version)) {
+          archive = await archive.checkout(version)
+        } else {
+          archive = await archive.checkout(await archive.getTaggedVersion(version))
+        }
+        await archive.ready()
+      }
+
+      const canonical = `hyper://${archive.key.toString('hex')}/${path || ''}`
+      responseHeaders.Link = `<${canonical}>; rel="canonical"`
+
+      const isWritable = writable && archive.writable
+      const allowHeaders = isWritable ? ALL_ALLOW : READABLE_ALLOW
+      responseHeaders.Allow = allowHeaders.join(', ')
+
+      // We can say the file hasn't changed if the drive version hasn't changed
+      responseHeaders.ETag = `"${archive.version}"`
+
+      if (method === 'TAG') {
+        const nameData = await collectBuffers(body)
+        const name = nameData.toString('utf8')
+        const tagVersion = archive.version
+
+        await archive.createTag(name, tagVersion)
+        responseHeaders['Content-Type'] = 'text/plain; charset=utf-8'
+
+        return {
+          statusCode: 200,
+          headers: responseHeaders,
+          data: intoAsyncIterable(`${tagVersion}`)
+        }
+      } else if (method === 'TAGS') {
+        const tags = await archive.getAllTags()
+        const tagsObject = Object.fromEntries(tags)
+        const json = JSON.stringify(tagsObject, null, '\t')
+
+        responseHeaders['Content-Type'] = 'application/json; charset=utf-8'
+
+        return {
+          statusCode: 200,
+          headers: responseHeaders,
+          data: intoAsyncIterable(json)
+        }
+      } else if (method === 'TAG-DELETE') {
+        await archive.deleteTag(version)
+
+        return {
+          statusCode: 200,
+          headers: responseHeaders,
+          data: intoAsyncIterable('')
+        }
+      } if (method === 'DOWNLOAD') {
+        await archive.download(path)
+        return {
+          statusCode: 200,
+          headers: responseHeaders,
+          data: intoAsyncIterable('')
+        }
+      } else if (method === 'CLEAR') {
+        await archive.clear(path)
+        return {
+          statusCode: 200,
+          headers: responseHeaders,
+          data: intoAsyncIterable('')
+        }
+      } else if (method === 'PUT') {
+        checkWritable(archive)
+        if (path.endsWith('/')) {
+          await makeDir(path, { fs: archive })
+        } else {
+          const parentDir = path.split('/').slice(0, -1).join('/')
+          if (parentDir) {
+            console.log('Making dir')
+            await makeDir(parentDir, { fs: archive })
+          }
+          // Create a new file from the request body
+          console.log('Getting source')
+          const source = Readable.from(body)
+          const destination = archive.createWriteStream(path)
+          console.log('Awaiting pipeline')
+          await pipelinePromise(source, destination)
+        }
+        return {
+          statusCode: 200,
+          headers: responseHeaders,
+          data: intoAsyncIterable('')
+        }
+      } else if (method === 'DELETE') {
+        checkWritable(archive)
+
+        const stats = await archive.stat(path)
+        // Weird stuff happening up in here...
+        const stat = Array.isArray(stats) ? stats[0] : stats
+
+        if (stat.isDirectory()) {
+          await archive.rmdir(path)
+        } else {
+          await archive.unlink(path)
+        }
+        return {
+          statusCode: 200,
+          headers: responseHeaders,
+          data: intoAsyncIterable('')
+        }
+      } else if ((method === 'GET') || (method === 'HEAD')) {
+        let stat = null
+        let finalPath = path
+
+        if (finalPath === '.well-known/dat') {
+          const { key } = archive
+          const entry = `dat://${key.toString('hex')}\nttl=3600`
+          console.log("Returning entry")
+          return {
+            statusCode: 200,
+            headers: responseHeaders,
+            data: intoAsyncIterable(entry)
+          }
+        }
+        try {
+          if (headers.get('X-Resolve') === 'none') {
+            [stat] = await archive.stat(path)
+          } else {
+            const resolved = await resolveDatPathAwait(archive, path)
+            finalPath = resolved.path
+            stat = resolved.stat
+          }
+        } catch (e) {
+          responseHeaders['content-type'] = 'text/plain'
+          return {
+            statusCode: 404,
+            headers: responseHeaders,
+            data: intoAsyncIterable(e.stack)
+          }
+        }
+
+        responseHeaders['Content-Type'] = getMimeType(finalPath)
+
+        let data = null
+        const isRanged = headers.get('Range') || headers.get('range')
+        let statusCode = 200
+
+        if (stat.isDirectory()) {
+          const stats = await archive.readdir(finalPath, { includeStats: true })
+          const files = stats.map(({ stat, name }) => (stat.isDirectory() ? `${name}/` : name))
+
+          if (headers.get('Accept') === 'application/json') {
+            const json = JSON.stringify(files, null, '\t')
+            responseHeaders['Content-Type'] = 'application/json; charset=utf-8'
+            data = intoAsyncIterable(json)
+          } else {
+            const page = `
+        <!DOCTYPE html>
+        <title>${url}</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <h1>Index of ${path}</h1>
+        <ul>
+          <li><a href="../">../</a></li>${files.map((file) => `
+          <li><a href="${file}">./${file}</a></li>
+        `).join('')}
+        </ul>
+      `
+            responseHeaders['Content-Type'] = 'text/html; charset=utf-8'
+            data = intoAsyncIterable(page)
+          }
+        } else {
+          responseHeaders['Accept-Ranges'] = 'bytes'
+
+          try {
+            const { blocks, downloadedBlocks } = await archive.stats(finalPath)
+            responseHeaders['X-Blocks'] = `${blocks}`
+            responseHeaders['X-Blocks-Downloaded'] = `${downloadedBlocks}`
+          } catch (e) {
+            // Don't worry about it, it's optional.
+          }
+
+          if (isRanged) {
+            const { size } = stat
+            const ranges = parseRange(size, isRanged)
+            if (ranges && ranges.length && ranges.type === 'bytes') {
+              statusCode = 206
+              const [{ start, end }] = ranges
+              const length = (end - start + 1)
+              responseHeaders['Content-Length'] = `${length}`
+              responseHeaders['Content-Range'] = `bytes ${start}-${end}/${size}`
+              if (method !== 'HEAD') {
+                data = archive.createReadStream(finalPath, {
+                  start,
+                  end
+                })
+              }
+            } else {
+              responseHeaders['Content-Length'] = `${size}`
+              if (method !== 'HEAD') {
+                data = archive.createReadStream(finalPath)
+              }
+            }
+          } else if (method !== 'HEAD') {
+            data = archive.createReadStream(finalPath)
+          }
+        }
+
+        if (method === 'HEAD') {
+          return {
+            statusCode: 200,
+            headers: responseHeaders,
+            data: intoAsyncIterable('')
+          }
+        } else {
+          return {
+            statusCode,
+            headers: responseHeaders,
+            data
+          }
+        }
+      } else {
+        return {
+          statusCode: 405,
+          headers: responseHeaders,
+          data: intoAsyncIterable('Method Not Allowed')
+        }
+      }
+    } catch (e) {
+      const isUnauthorized = (e.message === NOT_WRITABLE_ERROR)
+      const statusCode = isUnauthorized ? 403 : 500
+      const statusText = isUnauthorized ? 'Not Authorized' : 'Server Error'
+      return {
+        statusCode,
+        statusText,
+        headers: responseHeaders,
+        data: intoAsyncIterable(e.stack)
+      }
+    }
+  }
 
   function getResolve () {
     if (resolveName) return resolveName
@@ -38,6 +315,7 @@ module.exports = function makeFetch (opts = {}) {
 
   function getHyperdrive () {
     if (Hyperdrive) return Hyperdrive
+    console.log('Loading hyperdrive')
     return getSDK().then(({ Hyperdrive }) => Hyperdrive)
   }
 
@@ -70,232 +348,6 @@ module.exports = function makeFetch (opts = {}) {
       throw new Error(NOT_WRITABLE_ERROR)
     }
   }
-
-  async function datFetch (url, opts = {}) {
-    if (typeof url !== 'string') {
-      opts = url
-      url = opts.url
-    }
-
-    const isDatURL = url.startsWith('dat://') || url.startsWith('hyper://')
-    const urlHasProtocol = url.match(PROTOCOL_REGEX)
-
-    const shouldIntercept = isDatURL || (!urlHasProtocol && isSourceDat)
-
-    if (!shouldIntercept) throw new Error('Invalid protocol, must be dat:// or hyper://')
-
-    const { headers: rawHeaders, method: rawMethod } = opts
-    const headers = new Headers(rawHeaders || {})
-    const method = rawMethod ? rawMethod.toUpperCase() : 'GET'
-
-    const responseHeaders = new Headers()
-    responseHeaders.set('Access-Control-Allow-Origin', '*')
-    responseHeaders.set('Allow-CSP-From', '*')
-    responseHeaders.set('Access-Control-Allow-Headers', '*')
-    responseHeaders.set('Cache-Control', 'no-cache')
-
-    try {
-      let { path, key, version } = parseDatURL(url)
-      if (!path) path = '/'
-
-      const resolve = await getResolve()
-
-      try {
-        key = await resolve(`dat://${key}`)
-      } catch (e) {
-        // Probably a domain that couldn't resolve
-        if (key.includes('.')) throw e
-      }
-      const Hyperdrive = await getHyperdrive()
-
-      let archive = Hyperdrive(key)
-
-      await archive.ready()
-
-      if (version) {
-        if (NUMBER_REGEX.test(version)) {
-          archive = await archive.checkout(version)
-        } else {
-          archive = await archive.checkout(await archive.getTaggedVersion(version))
-        }
-        await archive.ready()
-      }
-
-      const canonical = `hyper://${archive.key.toString('hex')}/${path || ''}`
-      responseHeaders.append('Link', `<${canonical}>; rel="canonical"`)
-
-      const isWritable = writable && archive.writable
-      const allowHeaders = isWritable ? ALL_ALLOW : READABLE_ALLOW
-      responseHeaders.set('Allow', allowHeaders.join(', '))
-
-      // We can say the file hasn't changed if the drive version hasn't changed
-      responseHeaders.set('ETag', `"${archive.version}"`)
-
-      if (method === 'TAG') {
-        const { body } = opts
-        const name = (await concatPromise(bodyToStream(body, session))).toString('utf8')
-        const tagVersion = archive.version
-
-        await archive.createTag(name, tagVersion)
-        responseHeaders.set('Content-Type', 'text/plain; charset=utf-8')
-
-        return new FakeResponse(200, 'ok', responseHeaders, intoStream(`${tagVersion}`), url)
-      } else if (method === 'TAGS') {
-        const tags = await archive.getAllTags()
-        const tagsObject = Object.fromEntries(tags)
-        const json = JSON.stringify(tagsObject, null, '\t')
-
-        responseHeaders.set('Content-Type', 'application/json; charset=utf-8')
-
-        return new FakeResponse(200, 'ok', responseHeaders, intoStream(Buffer.from(json)), url)
-      } else if (method === 'TAG-DELETE') {
-        await archive.deleteTag(version)
-
-        return new FakeResponse(200, 'ok', responseHeaders, intoStream(''), url)
-      } if (method === 'DOWNLOAD') {
-        await archive.download(path)
-        return new FakeResponse(200, 'ok', responseHeaders, intoStream(''), url)
-      } else if (method === 'CLEAR') {
-        await archive.clear(path)
-        return new FakeResponse(200, 'ok', responseHeaders, intoStream(''), url)
-      } else if (method === 'PUT') {
-        checkWritable(archive)
-        if (path.endsWith('/')) {
-          await makeDir(path, { fs: archive })
-        } else {
-          const parentDir = path.split('/').slice(0, -1).join('/')
-          if (parentDir) {
-            await makeDir(parentDir, { fs: archive })
-          }
-          // Create a new file from the request body
-          const { body } = opts
-          const source = bodyToStream(body, session)
-          const destination = archive.createWriteStream(path)
-
-          await pump(source, destination)
-        }
-        return new FakeResponse(200, 'OK', responseHeaders, intoStream(''), url)
-      } else if (method === 'DELETE') {
-        checkWritable(archive)
-
-        const stats = await archive.stat(path)
-        // Weird stuff happening up in here...
-        const stat = Array.isArray(stats) ? stats[0] : stats
-
-        if (stat.isDirectory()) {
-          await archive.rmdir(path)
-        } else {
-          await archive.unlink(path)
-        }
-
-        return new FakeResponse(200, 'OK', responseHeaders, intoStream(''), url)
-      } else if ((method === 'GET') || (method === 'HEAD')) {
-        let stat = null
-        let finalPath = path
-
-        if (finalPath === '.well-known/dat') {
-          const { key } = archive
-          const entry = `dat://${key.toString('hex')}\nttl=3600`
-          return new FakeResponse(200, 'OK', responseHeaders, intoStream(entry), url)
-        }
-        try {
-          if (headers.get('X-Resolve') === 'none') {
-            [stat] = await archive.stat(path)
-          } else {
-            const resolved = await resolveDatPathAwait(archive, path)
-            finalPath = resolved.path
-            stat = resolved.stat
-          }
-        } catch (e) {
-          return new FakeResponse(
-            404,
-            'Not Found',
-            new Headers([
-              'content-type', 'text/plain'
-            ]),
-            intoStream(e.stack),
-            url)
-        }
-
-        responseHeaders.set('Content-Type', getMimeType(finalPath))
-
-        let stream = null
-        const isRanged = headers.get('Range') || headers.get('range')
-        let statusCode = 200
-
-        if (stat.isDirectory()) {
-          const stats = await archive.readdir(finalPath, { includeStats: true })
-          const files = stats.map(({ stat, name }) => (stat.isDirectory() ? `${name}/` : name))
-
-          if (headers.get('Accept') === 'application/json') {
-            const json = JSON.stringify(files, null, '\t')
-            responseHeaders.set('Content-Type', 'application/json; charset=utf-8')
-            stream = intoStream(Buffer.from(json))
-          } else {
-            const page = `
-        <!DOCTYPE html>
-        <title>${url}</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <h1>Index of ${path}</h1>
-        <ul>
-          <li><a href="../">../</a></li>${files.map((file) => `
-          <li><a href="${file}">./${file}</a></li>
-        `).join('')}
-        </ul>
-      `
-            responseHeaders.set('Content-Type', 'text/html; charset=utf-8')
-            const buffer = Buffer.from(page)
-            stream = intoStream(buffer)
-          }
-        } else {
-          responseHeaders.set('Accept-Ranges', 'bytes')
-
-          try {
-            const { blocks, downloadedBlocks } = await archive.stats(finalPath)
-            responseHeaders.set('X-Blocks', `${blocks}`)
-            responseHeaders.set('X-Blocks-Downloaded', `${downloadedBlocks}`)
-          } catch (e) {
-            // Don't worry about it, it's optional.
-          }
-
-          if (isRanged) {
-            const { size } = stat
-            const ranges = parseRange(size, isRanged)
-            if (ranges && ranges.length && ranges.type === 'bytes') {
-              statusCode = 206
-              const [{ start, end }] = ranges
-              const length = (end - start + 1)
-              responseHeaders.set('Content-Length', `${length}`)
-              responseHeaders.set('Content-Range', `bytes ${start}-${end}/${size}`)
-              stream = archive.createReadStream(finalPath, {
-                start,
-                end
-              })
-            } else {
-              responseHeaders.set('Content-Length', `${size}`)
-              stream = archive.createReadStream(finalPath)
-            }
-          } else {
-            stream = archive.createReadStream(finalPath)
-          }
-        }
-
-        if (method === 'HEAD') {
-          stream.destroy()
-          return new FakeResponse(204, 'ok', responseHeaders, intoStream(''), url)
-        } else {
-          return new FakeResponse(statusCode, 'ok', responseHeaders, stream, url)
-        }
-      } else {
-        return new FakeResponse(405, 'Method Not Allowed', responseHeaders, intoStream('Method Not Allowed'), url)
-      }
-    } catch (e) {
-      const isUnauthorized = (e.message === NOT_WRITABLE_ERROR)
-      const status = isUnauthorized ? 403 : 500
-      const message = isUnauthorized ? 'Not Authorized' : 'Server Error'
-      return new FakeResponse(status, message, responseHeaders, intoStream(e.stack), url)
-    }
-  }
 }
 
 function parseDatURL (url) {
@@ -310,53 +362,17 @@ function parseDatURL (url) {
   }
 }
 
-class FakeResponse {
-  constructor (status, statusText, headers, stream, url) {
-    this.body = stream
-    this.headers = headers
-    this.url = url
-    this.status = status
-    this.statusText = statusText
-  }
-
-  get ok () {
-    return this.status && this.status < 400
-  }
-
-  get useFinalURL () {
-    return true
-  }
-
-  async arrayBuffer () {
-    const buffer = await concatPromise(this.body)
-    return buffer.buffer
-  }
-
-  async text () {
-    const buffer = await concatPromise(this.body)
-    return buffer.toString('utf-8')
-  }
-
-  async json () {
-    return JSON.parse(await this.text())
-  }
+async function * intoAsyncIterable (data) {
+  yield Buffer.from(data)
 }
 
-function concatPromise (stream) {
-  return new Promise((resolve, reject) => {
-    var concatStream = concat(resolve)
-    concatStream.once('error', reject)
-    stream.pipe(concatStream)
-  })
-}
+async function collectBuffers (iterable) {
+  const all = []
+  for await (const buff of iterable) {
+    all.push(Buffer.from(buff))
+  }
 
-function intoStream (data) {
-  return new Readable({
-    read () {
-      this.push(data)
-      this.push(null)
-    }
-  })
+  return Buffer.concat(all)
 }
 
 function getMimeType (path) {

--- a/package.json
+++ b/package.json
@@ -30,10 +30,12 @@
     "fetch-headers": "^2.0.0",
     "fetch-request-body-to-stream": "^1.0.0",
     "make-dir": "^3.1.0",
+    "make-fetch": "^2.2.1",
     "mime": "^2.4.4",
     "pump-promise": "^1.0.0",
     "range-parser": "^1.2.1",
-    "resolve-dat-path": "^1.2.0"
+    "resolve-dat-path": "^1.2.0",
+    "streamx": "^2.10.0"
   },
   "devDependencies": {
     "dat-sdk": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dat-fetch",
+  "name": "hyper-fetch",
   "version": "5.1.1",
   "description": "Implementation of Fetch that uses the Dat SDK for loading p2p content",
   "bin": "bin.js",
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/RangerMauve/dat-fetch.git"
+    "url": "git+https://github.com/RangerMauve/hyper-fetch.git"
   },
   "keywords": [
     "dat",
@@ -18,27 +18,21 @@
   "author": "RangerMauve",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/RangerMauve/dat-fetch/issues"
+    "url": "https://github.com/RangerMauve/hyper-fetch/issues"
   },
-  "homepage": "https://github.com/RangerMauve/dat-fetch#readme",
-  "peerDependencies": {
-    "dat-sdk": "^2.0.0"
-  },
+  "homepage": "https://github.com/RangerMauve/hyper-fetch#readme",
   "dependencies": {
-    "concat-stream": "^2.0.0",
-    "end-of-stream-promise": "^1.0.0",
     "fetch-headers": "^2.0.0",
-    "fetch-request-body-to-stream": "^1.0.0",
+    "hyper-sdk": "^3.0.3",
     "make-dir": "^3.1.0",
     "make-fetch": "^2.2.1",
     "mime": "^2.4.4",
-    "pump-promise": "^1.0.0",
     "range-parser": "^1.2.1",
     "resolve-dat-path": "^1.2.0",
+    "sodium-universal": "^3.0.2",
     "streamx": "^2.10.0"
   },
   "devDependencies": {
-    "dat-sdk": "^2.8.1",
     "random-access-memory": "^3.1.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -5,145 +5,149 @@ async function test () {
     persist: false
   })
 
-  const archive = Hyperdrive('dat fetch test')
+  try {
+    const archive = Hyperdrive('example')
 
-  const FILE_LOCATION = '/index.html'
+    const FILE_LOCATION = '/index.html'
 
-  await archive.writeFile(FILE_LOCATION, '<h1>Hello World!</h1>')
+    await archive.writeFile(FILE_LOCATION, '<h1>Hello World!</h1>')
 
-  const fetch = require('./')({
-    Hyperdrive,
-    resolveName,
-    writable: true
-  })
+    const fetch = require('./')({
+      Hyperdrive,
+      resolveName,
+      writable: true
+    })
 
-  const url = `dat://${archive.key.toString('hex')}${FILE_LOCATION}`
+    const url = `dat://${archive.key.toString('hex')}${FILE_LOCATION}`
 
-  console.log('Fetching from', url)
+    console.log('Fetching from', url)
 
-  const response = await fetch(url)
+    const response = await fetch(url)
 
-  const text = await response.text()
+    const text = await response.text()
 
-  const contentType = response.headers.get('content-type')
+    const contentType = response.headers.get('content-type')
 
-  console.log(contentType)
-  console.log(text)
-  console.log([...response.headers.entries()])
+    console.log(contentType)
+    console.log(text)
+    console.log([...response.headers.entries()])
 
-  const sampleContents = 'Hello World'
+    const sampleContents = 'Hello World'
 
-  // Gets
-  console.log('\nGET TESTS')
-  testItem(
-    await (await fetch('hyper://example/.well-known/dat')).text(),
-    'Check well-known dat'
-  )
-  testItem(
-    (await fetch('hyper://example/checkthis.txt', {method: 'PUT', body: sampleContents})).status,
-    'Put file to check',
-    200
-  )
-  testItem(
-    await (await fetch('hyper://example/checkthis.txt', {method: 'GET'})).text(),
-    'Check written file',
-    sampleContents
-  )
+    // Gets
+    console.log('\nGET TESTS')
+    testItem(
+      await (await fetch('hyper://example/.well-known/dat')).text(),
+      'Check well-known dat'
+    )
+    testItem(
+      (await fetch('hyper://example/checkthis.txt', { method: 'PUT', body: sampleContents })).status,
+      'Put file to check',
+      200
+    )
+    testItem(
+      await (await fetch('hyper://example/checkthis.txt', { method: 'GET' })).text(),
+      'Check written file',
+      sampleContents
+    )
 
-  // Puts
-  console.log('\nPUT TESTS')
-  testItem(
-    (await fetch('hyper://example/foo/bar/', {method: 'PUT'})).status,
-    'Put directories',
-    200
-  )
-  testItem(
-    (await fetch('hyper://example/fizz/buzz/example.txt', {method: 'PUT', body: sampleContents})).status,
-    'Put file under new directories',
-    200
-  )
-  testItem(
-    (await fetch('hyper://example/baz/index.html', {method: 'PUT', body: sampleContents})).status,
-    'Put file',
-    200
-  )
-  testItem(
-    (await fetch('hyper://example/baz/index.html', {method: 'PUT', body: sampleContents})).status,
-    'Put file over other',
-    200
-  )
+    // Puts
+    console.log('\nPUT TESTS')
+    testItem(
+      (await fetch('hyper://example/foo/bar/', { method: 'PUT' })).status,
+      'Put directories',
+      200
+    )
+    testItem(
+      (await fetch('hyper://example/fizz/buzz/example.txt', { method: 'PUT', body: sampleContents })).status,
+      'Put file under new directories',
+      200
+    )
+    testItem(
+      (await fetch('hyper://example/baz/index.html', { method: 'PUT', body: sampleContents })).status,
+      'Put file',
+      200
+    )
+    testItem(
+      (await fetch('hyper://example/baz/index.html', { method: 'PUT', body: sampleContents })).status,
+      'Put file over other',
+      200
+    )
 
-  // Deletes
-  console.log('\nDELETE TESTS')
-  testItem(
-    (await fetch('hyper://example/test.txt', {method: 'PUT', body: sampleContents})).status,
-    'Create file for deletion',
-    200
-  )
-  testItem(
-    (await fetch('hyper://example/test.txt', {method: 'HEAD'})).status,
-    'Check file',
-    204
-  )
-  testItem(
-    (await fetch('hyper://example/test.txt', {method: 'DELETE'})).status,
-    'Delete file',
-    200
-  )
-  testItem(
-    (await fetch('hyper://example/test.txt', {method: 'GET'})).status,
-    'Deleted file',
-    404
-  )
+    // Deletes
+    console.log('\nDELETE TESTS')
+    testItem(
+      (await fetch('hyper://example/test.txt', { method: 'PUT', body: sampleContents })).status,
+      'Create file for deletion',
+      200
+    )
+    testItem(
+      (await fetch('hyper://example/test.txt', { method: 'HEAD' })).status,
+      'Check file',
+      204
+    )
+    testItem(
+      (await fetch('hyper://example/test.txt', { method: 'DELETE' })).status,
+      'Delete file',
+      200
+    )
+    testItem(
+      (await fetch('hyper://example/test.txt', { method: 'GET' })).status,
+      'Deleted file',
+      404
+    )
 
-  // Directories
-  console.log('\nDIRECTORY TESTS')
-  testItem(
-    await (await fetch('hyper://example/baz')).text(),
-    'Resolve index',
-    sampleContents
-  )
-  testItem(
-    await (await fetch('hyper://example/baz', {headers: {'X-Resolve': 'none'}})).text(),
-    'Bypass resolve and recieve as JSON'
-  )
-  testItem(
-    await (await fetch('hyper://example/baz', {headers: {'X-Resolve': 'none', 'Accept': 'application/json'}})).json(),
-    'Bypass resolve and recieve as JSON',
-    ['index.html']
-  )
+    // Directories
+    console.log('\nDIRECTORY TESTS')
+    testItem(
+      await (await fetch('hyper://example/baz')).text(),
+      'Resolve index',
+      sampleContents
+    )
+    testItem(
+      await (await fetch('hyper://example/baz', { headers: { 'X-Resolve': 'none' } })).text(),
+      'Bypass resolve and recieve as JSON'
+    )
+    testItem(
+      await (await fetch('hyper://example/baz', { headers: { 'X-Resolve': 'none', Accept: 'application/json' } })).json(),
+      'Bypass resolve and recieve as JSON',
+      ['index.html']
+    )
 
-  // Tags
-  console.log('\nTAG TESTS')
-  await fetch('hyper://example/test.txt', {method:'PUT', body:'test'})
-  testItem(
-    (await fetch('hyper://example/', {method: 'TAG', body: 'tag1'})).status,
-    'Create tag',
-    200
-  )
-  testItem(
-    await (await fetch('hyper://example/', {method: 'TAGS'})).json(),
-    'Get tags',
-    {tag1: 11}
-  )
-  testItem(
-    await (await fetch('hyper://example+tag1/test.txt', {method: 'GET'})).text(),
-    'Access tag',
-    'test'
-  )
-  await fetch('hyper://example/notaccessible.txt', {method:'PUT', body:'test'})
-  testItem(
-    (await fetch('hyper://example+tag1/notaccessible.txt', {method: 'GET'})).status,
-    'Fetch new data from old tag',
-    404
-  )
-  testItem(
-    (await fetch('hyper://example+tag1/', {method: 'TAG-DELETE'})).status,
-    'Delete tag',
-    200
-  )
-
-  await close()
+    // Tags
+    console.log('\nTAG TESTS')
+    await fetch('hyper://example/test.txt', { method: 'PUT', body: 'test' })
+    testItem(
+      (await fetch('hyper://example/', { method: 'TAG', body: 'tag1' })).status,
+      'Create tag',
+      200
+    )
+    testItem(
+      await (await fetch('hyper://example/', { method: 'TAGS' })).json(),
+      'Get tags',
+      { tag1: 11 }
+    )
+    testItem(
+      await (await fetch('hyper://example+tag1/test.txt', { method: 'GET' })).text(),
+      'Access tag',
+      'test'
+    )
+    await fetch('hyper://example/notaccessible.txt', { method: 'PUT', body: 'test' })
+    testItem(
+      (await fetch('hyper://example+tag1/notaccessible.txt', { method: 'GET' })).status,
+      'Fetch new data from old tag',
+      404
+    )
+    testItem(
+      (await fetch('hyper://example+tag1/', { method: 'TAG-DELETE' })).status,
+      'Delete tag',
+      200
+    )
+  } catch (e) {
+    console.log(e.stack)
+  } finally {
+    await close()
+  }
 }
 
 test().then(() => {
@@ -163,9 +167,9 @@ async function checkOK (response) {
   return response
 }
 
-function testItem(value, testname, expected) {
+function testItem (value, testname, expected) {
   value = JSON.stringify(value)
   expected = JSON.stringify(expected)
-  if(expected && expected != value) console.log(`!!! ${testname} failed, expected ${expected}; got ${value} !!!`)
+  if (expected && expected != value) console.log(`!!! ${testname} failed, expected ${expected}; got ${value} !!!`)
   else console.log(`${testname} ${expected ? 'succeeded' : 'assumed to have succeeded'}`)
 }

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-const SDK = require('dat-sdk')
+const SDK = require('hyper-sdk')
 
 async function test () {
   const { Hyperdrive, resolveName, close } = await SDK({
@@ -18,7 +18,7 @@ async function test () {
       writable: true
     })
 
-    const url = `dat://${archive.key.toString('hex')}${FILE_LOCATION}`
+    const url = `hyper://${archive.key.toString('hex')}${FILE_LOCATION}`
 
     console.log('Fetching from', url)
 
@@ -151,9 +151,8 @@ async function test () {
 test().then(() => {
   process.exit(0)
 }, (e) => {
-  process.nextTick(() => {
-    throw e
-  })
+  console.error(e.stack)
+  process.exit(1)
 })
 
 function testItem (value, testname, expected) {

--- a/test.js
+++ b/test.js
@@ -125,7 +125,7 @@ async function test () {
     testItem(
       await (await fetch('hyper://example/', { method: 'TAGS' })).json(),
       'Get tags',
-      { tag1: 11 }
+      { tag1: 12 }
     )
     testItem(
       await (await fetch('hyper://example+tag1/test.txt', { method: 'GET' })).text(),
@@ -143,8 +143,6 @@ async function test () {
       'Delete tag',
       200
     )
-  } catch (e) {
-    console.log(e.stack)
   } finally {
     await close()
   }
@@ -158,18 +156,9 @@ test().then(() => {
   })
 })
 
-async function checkOK (response) {
-  if (!response.ok) {
-    const message = await response.text()
-    throw new Error(message)
-  }
-
-  return response
-}
-
 function testItem (value, testname, expected) {
   value = JSON.stringify(value)
   expected = JSON.stringify(expected)
-  if (expected && expected != value) console.log(`!!! ${testname} failed, expected ${expected}; got ${value} !!!`)
+  if (expected && expected !== value) console.log(`!!! ${testname} failed, expected ${expected}; got ${value} !!!`)
   else console.log(`${testname} ${expected ? 'succeeded' : 'assumed to have succeeded'}`)
 }


### PR DESCRIPTION
This gets rid of a lot of the fetch API implementation like FakeResponse and instead uses the implementation in make-fetch in order to simplify the code.

Adds missing method names in the Allow header.

Also gets rid of some of the old stream code, uses streamx since that's probably going to be used by Hyperdrive and Hypercore internally.